### PR TITLE
Add key "Main" on bower.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,10 @@
     "angular-mocks": "*"
   },
   "license": "MIT",
+  "main": [
+    "dist/vidBg.css",
+    "dist/vidBg.js"
+  ],
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
I am working with gulp and I had some trouble in inject the scripts and css on the html page automatically because without the "main" the system doesn't know which file to include in the page.
